### PR TITLE
No line coloring for old/new file version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -264,7 +264,7 @@ dependencies = [
 
 [[package]]
 name = "git-igitt"
-version = "0.1.14"
+version = "0.1.15"
 dependencies = [
  "clap",
  "crossterm 0.19.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "git-igitt"
-version = "0.1.14"
+version = "0.1.15"
 authors = ["Martin Lange <martin_lange_@gmx.net>"]
 edition = "2018"
 

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -414,7 +414,7 @@ fn draw_diff<B: Backend>(f: &mut Frame<B>, target: Rect, app: &mut App) {
             }
         } else {
             if !state.diffs.is_empty() {
-                text.extend(style_diff_line(None, &state.diffs[0].0, &styles, app.color));
+                text.extend(style_diff_line(None, &state.diffs[0].0, &styles, false));
             }
             if !state.diffs.len() > 1 {
                 if let Some(txt) = &state.highlighted {
@@ -428,7 +428,7 @@ fn draw_diff<B: Backend>(f: &mut Frame<B>, target: Rect, app: &mut App) {
                             if trim.is_empty() {
                                 text.extend(Text::raw("\n"));
                             } else {
-                                let styled = style_diff_line(None, trim, &styles, app.color);
+                                let styled = style_diff_line(None, trim, &styles, false);
                                 text.extend(styled);
                             }
                         }


### PR DESCRIPTION
Lines starting with +/- were green/red when syntax highlighting is turned off.

Fixes #52.