### PR TITLE
green up CI, test builds using lockfile

### DIFF
--- a/.github/workflows/crates-io.yml
+++ b/.github/workflows/crates-io.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v5
       - name: Install Rust
         uses: actions-rs/toolchain@v1
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,7 +36,7 @@ jobs:
             os_name: "macos-amd64"
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v5
       - name: Get tag
         run: echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
         shell: bash
@@ -65,7 +65,7 @@ jobs:
           tar -czf release.tar.gz $REPO${{ matrix.bin_extension }}
         shell: bash
       - name: Archive artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v5
         with:
           name: build-${{ matrix.os_name }}
           path: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,7 +58,7 @@ jobs:
 
       - name: Build
         run: |
-          cargo build --target ${{ matrix.target }} --release
+          cargo build --locked --target ${{ matrix.target }} --release
       - name: Compress
         run: |
           cp -f target/${{ matrix.target }}/release/$REPO${{ matrix.bin_extension }} .

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,7 +2,7 @@ name: Tests
 
 on:
   push:
-    branches: [ master ]
+    branches: ["**"]
   pull_request:
     branches: [ master ]
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v2
+        uses: actions/checkout@v5
 
       - name: Install stable toolchain
         uses: actions-rs/toolchain@v1
@@ -35,7 +35,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v2
+        uses: actions/checkout@v5
 
       - name: Install stable toolchain
         uses: actions-rs/toolchain@v1


### PR DESCRIPTION
This is part 2, a follow up to #69 that addresses checking for the lockfile issue raised in #68. It shouldn't matter what order these are merged. CI is currently failing for various reasons, this makes it work but the repo is broken, so if merged first the results will be red. If merged second they should be green. A sample of working runs can be [seen here on my fork](https://github.com/alerque/git-igitt/actions/runs/19199108366) and [here for the other workflow](https://github.com/alerque/git-igitt/actions/runs/19199108363).

Note I can't test the crates.io publish workflow. Yet :wink:
