### PR TITLE
tag patch level release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -454,7 +454,7 @@ dependencies = [
 
 [[package]]
 name = "git-igitt"
-version = "0.1.18"
+version = "0.1.19"
 dependencies = [
  "clap",
  "crossterm 0.29.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "git-igitt"
-version = "0.1.18"
+version = "0.1.19"
 authors = ["Martin Lange <martin_lange_@gmx.net>"]
 description = "Interactive Git terminal application to browse and visualize Git history graphs arranged for your branching model"
 repository = "https://github.com/mlange-42/git-igitt.git"


### PR DESCRIPTION
In order to fully resolve #68, we need a new tagged release. Only then can distro packaging actually be reproducable and not require backporting some of the work done in *master* to even compile.

This PR includes the necessary manifest and lockfile changes to release, but doesn't actually tag it. 

- [ ] After merging (rebase or squash is fine to not introduce a needless merge commit) whatever the HEAD commit ends up being should be tagged and the tag pushed to the repo.
- [ ] Then the tag should be marked as a GH release (notes for that included below)
* [ ] That *should* cause an automatic publish to crates.io, so after releasesing the last thing to do is check that the publish happened correctly.

---

* Add reverse order option
* Correct panic handling to not mess up terminal
* Add debug logging
* Refresh dependencies
* Include synced lock file for reproducability
