### PR TITLE
Fix CPU/GPU usage in file dialog and crash with single-commit repos

### DIFF
--- a/src/dialogs.rs
+++ b/src/dialogs.rs
@@ -31,7 +31,7 @@ impl<'a> FileDialog<'a> {
 
     pub fn fwd(&mut self, steps: usize) {
         let i = match self.state.selected() {
-            Some(i) => std::cmp::min(i.saturating_add(steps), self.dirs.len() - 1),
+            Some(i) => std::cmp::min(i.saturating_add(steps), self.dirs.len().saturating_sub(1)),
             None => 0,
         };
         self.state.select(Some(i));

--- a/src/widgets/models_view.rs
+++ b/src/widgets/models_view.rs
@@ -17,7 +17,7 @@ impl ModelListState {
 
     pub fn fwd(&mut self, steps: usize) {
         let i = match self.state.selected() {
-            Some(i) => std::cmp::min(i.saturating_add(steps), self.models.len() - 1),
+            Some(i) => std::cmp::min(i.saturating_add(steps), self.models.len().saturating_sub(1)),
             None => 0,
         };
         self.state.select(Some(i));


### PR DESCRIPTION
## Summary

This PR fixes two bugs:

### Bug 1: 100% CPU/GPU usage in file dialog view
- **Cause**: Event loop ignored `Event::Update` when showing the file dialog, causing `next_repo_refresh` to never update after expiration. This resulted in `poll()` returning immediately with zero timeout, creating a busy loop.
- **Fix**: Changed `if let Event::Input` to `match` statements that handle both `Event::Input` and `Event::Update`, updating the refresh timer in both branches.

### Bug 2: Crash with single-commit repositories
- **Cause**: Multiple places used `len() - 1` which causes unsigned integer underflow when length is 0 (wraps to `usize::MAX`). This caused invalid comparisons and out-of-bounds index access.
- **Fix**: 
  - Added guard for empty `indices` in graph_view render function
  - Changed `len() - 1` to `len().saturating_sub(1)` throughout
  - Used safe `.get(idx).copied()` instead of direct indexing
  - Pre-computed max index values to avoid repeated calculations

## Testing

- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --all --all-targets -- --deny warnings` passes
- [x] `cargo test --all` passes
- [x] Release build succeeds