### PR TITLE
Fix doubled key inputs on Windows. (#76)

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,6 @@
 use clap::{crate_version, Arg, Command};
 use crossterm::{
-    event::{self, Event as CEvent, KeyCode, KeyModifiers},
+    event::{self, Event as CEvent, KeyCode, KeyModifiers, KeyEventKind},
     execute,
     terminal::{disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen},
 };
@@ -503,7 +503,11 @@ fn run(
 
             if event::poll(timeout).unwrap() {
                 match event::read().unwrap() {
-                    CEvent::Key(key) => return Event::Input(key),
+                    CEvent::Key(key) => {
+                        if key.kind == KeyEventKind::Press || key.kind == KeyEventKind::Repeat {
+                            return Event::Input(key);
+                        }
+                    },
                     CEvent::Mouse(_) => (),
                     CEvent::Resize(sx, sy) => {
                         if sx != sx_old || sy != sy_old {


### PR DESCRIPTION
Fixes #76 on Windows.

I have no access to the other supported build targets to check for regressions, unfortunately. Hopefully this simple fix does not break anything else.

---

On Windows, it appears that separate events are sent for keydown and keyup, which are both processed by the input handler causing all keyboard shortcut inputs to be repeated twice. This makes some features in particular the sidebar ( key) fully unusable on Windows. Running it in WSL solves the issue, but this simple fix should as well.